### PR TITLE
tglogin: increase 2FA pass maxLength

### DIFF
--- a/src/ui/elements/input/input.tsx
+++ b/src/ui/elements/input/input.tsx
@@ -49,7 +49,7 @@ export const Input: FC<Props> = memo(({
   icon,
   iconClass: iconClassName,
   forwardedRef,
-  maxLength = 50,
+  maxLength = 256,
   autoFocus,
   fakeFocus,
   clear,


### PR DESCRIPTION
256 is used in web.telegram.org.